### PR TITLE
Issue #9: Frontend — /status command user-facing layer

### DIFF
--- a/app/bot/formatters/status_formatter.py
+++ b/app/bot/formatters/status_formatter.py
@@ -35,7 +35,7 @@ class StatusFormatter:
         header = (
             f"*Your Standup Status*\n"
             f"Week of: {week_anchor}\n"
-            f"Submitted: {submitted_at or '_unknown_'}\n"
+            f"Submitted: {submitted_at or '\\_unknown\\_'}\n"
             f"Review status: {emoji} {status_label}\n\n"
         )
 


### PR DESCRIPTION
## Changes

- Fixed MarkdownV2 escaping bug in `status_formatter.py`: replaced unescaped `'_unknown_'` fallback with `'\\_unknown\\_'` so the submitted_at fallback renders correctly in Telegram MarkdownV2 parse mode
- Verified all static formatter strings (`_no_tasks_message`, `group_acknowledge_message`, `error_message`) have correct MarkdownV2 dot escaping (`\\.`)
- Verified DM fallback error message in `status_handler.py` uses single-escaped dot (`\\.`) as required by MarkdownV2

## How to Test

1. Start the bot and send `/status` in a private chat with no submissions this week → should show "_You haven't submitted a standup for this week yet._"
2. Submit a standup, then send `/status` → should show formatted status with week, timestamp, review status, and task list
3. Send `/status` in a group chat → bot should reply publicly "Checking your status. Please check your Direct Messages." and DM the result
4. If bot cannot DM you (no prior DM), group fallback message should appear cleanly formatted
5. Simulate DB error → should show "Sorry, I couldn't retrieve your status right now. Please try again later."

## Acceptance Criteria Coverage

- [x] `/status` responds in channel (group ack) or private DM
- [x] Tasks for current ISO week listed with description, timestamp, status
- [x] No-tasks-this-week message is clear and readable
- [x] Scoped to requesting user only (user_id from update, never passed as param)
- [x] MarkdownV2 formatted — all special chars properly escaped
- [x] Error states return user-friendly message, no traceback

## Linked Issue
Closes #9

@ARCH: please review