### PR TITLE
Issue #12: Frontend — Register /status in Telegram bot command menu

### DIFF
--- a/app/bot/commands.py
+++ b/app/bot/commands.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from telegram import BotCommand
+from telegram.ext import Application
+
+COMMANDS: List[BotCommand] = [
+    BotCommand("status", "Check your submitted tasks for this week"),
+]
+
+
+async def register_commands(application: Application) -> None:
+    """
+    Registers the defined commands with Telegram so they appear in the bot menu.
+    """
+    await application.bot.set_my_commands(COMMANDS)

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ import os
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from telegram.ext import Application
 
+from app.bot.commands import register_commands
 from app.bot.router import setup_router
 
 logging.basicConfig(
@@ -29,8 +30,14 @@ async def main() -> None:
     application = Application.builder().token(bot_token).build()
     setup_router(application, session_factory)
 
-    logger.info("Starting bot...")
+    logger.info("Initializing bot...")
     await application.initialize()
+
+    # Register commands for Telegram UI menu
+    await register_commands(application)
+    logger.info("Bot commands registered.")
+
+    logger.info("Starting bot...")
     await application.start()
     await application.updater.start_polling(drop_pending_updates=True)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,14 @@
+from app.bot.commands import COMMANDS
+
+
+def test_status_command_exists() -> None:
+    """Verify that the /status command is defined."""
+    status_commands = [cmd for cmd in COMMANDS if cmd.command == "status"]
+    assert len(status_commands) == 1, "Status command should be defined exactly once"
+
+
+def test_status_command_description() -> None:
+    """Verify that the /status command has the correct description."""
+    status_cmd = next((cmd for cmd in COMMANDS if cmd.command == "status"), None)
+    assert status_cmd is not None
+    assert status_cmd.description == "Check your submitted tasks for this week"


### PR DESCRIPTION
## Changes

- **New**: `app/bot/commands.py` — defines `COMMANDS` list with `/status` and `register_commands()` async function that calls `set_my_commands` on the Telegram bot
- **Modified**: `app/main.py` — imports and calls `register_commands()` after `application.initialize()` so the command appears in Telegram's UI menu
- **New**: `tests/test_commands.py` — verifies the `/status` command is defined exactly once with the correct description

## How to Test

1. Start the bot with valid `BOT_TOKEN` and `DATABASE_URL`
2. Open Telegram and search for the bot
3. Type `/` in the chat — you should see `/status` appear in the autocomplete menu with description "Check your submitted tasks for this week"
4. Run `pytest tests/test_commands.py` — all tests should pass

## Edge Cases Handled

- Command registration happens after `initialize()` to ensure the bot client is ready
- `register_commands` is idempotent — calling `set_my_commands` replaces any existing command list

## Linked Issue

Closes #12

## ARCH Review Requested

@ARCH: please review this PR. Backend logic is on `feature/issue-12-backend`. This PR adds the Telegram command menu registration layer on top.