### PR TITLE
Issue #16: Backend

### DIFF
--- a/app/bot/formatters/reminder_formatter.py
+++ b/app/bot/formatters/reminder_formatter.py
@@ -1,0 +1,37 @@
+"""
+Formatters for reminder messages.
+"""
+
+def format_squad_reminder(squad_name: str) -> str:
+    """
+    Formats the message sent to a squad channel or member.
+    """
+    return (
+        f"👋 *Weekly Update Reminder*\n\n"
+        f"Hi team {squad_name}! It looks like your weekly standup update is missing or incomplete.\n\n"
+        f"Please take a moment to submit your update now so we can keep track of blockers and progress.\n"
+        f"Use the /submit command to report."
+    )
+
+def format_no_reminders_needed() -> str:
+    """
+    Formats the response when all squads have submitted.
+    """
+    return "✅ All squads have submitted their weekly updates. No reminders needed."
+
+def format_lead_summary(reminded_squads: list[str], skipped_squads: list[str] = None) -> str:
+    """
+    Formats the summary sent back to the QA Lead.
+    """
+    if not reminded_squads:
+        return format_no_reminders_needed()
+
+    msg = "🔔 *Reminders Sent*\n\n"
+    msg += f"Sent reminders to **{len(reminded_squads)}** squad(s):\n"
+    for squad in reminded_squads:
+        msg += f"• {squad}\n"
+
+    if skipped_squads:
+        msg += f"\n⚠️ Skipped {len(skipped_squads)} squad(s) due to missing chat configuration or members."
+
+    return msg

--- a/app/bot/handlers/remind_handler.py
+++ b/app/bot/handlers/remind_handler.py
@@ -1,0 +1,63 @@
+"""
+Handler for the /remind slash command.
+Restricted to QA Leads.
+"""
+import os
+import logging
+from typing import Optional
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from app.services.reminder_service import ReminderService
+from app.bot.formatters.reminder_formatter import format_lead_summary
+from app.db.session import get_db
+
+logger = logging.getLogger(__name__)
+
+QA_LEAD_IDS = set(int(uid) for uid in os.getenv("QA_LEAD_IDS", "").split(",") if uid.strip())
+
+async def remind_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """
+    /remind command handler.
+    Identifies squads missing updates and sends reminders.
+    """
+    user_id = update.effective_user.id
+
+    # 1. Authorization Check
+    if user_id not in QA_LEAD_IDS:
+        await update.message.reply_text("⛔ You do not have permission to use this command.")
+        return
+
+    # 2. Initialize Service
+    # Note: We need a DB session and a bot instance.
+    # We fetch the bot instance from context.bot if compatible, or pass it.
+    # Assuming context.bot is the standard python-telegram-bot application instance.
+
+    # We need to manage the DB session lifecycle carefully in a handler.
+    db_gen = get_db()
+    db = next(db_gen)
+
+    try:
+        # Assuming ReminderService expects a bot instance with async send_message
+        # We wrap context.bot if necessary or pass it directly
+        service = ReminderService(db, context.bot)
+
+        # 3. Identify Missing Squads
+        missing_squads = service.get_missing_squads(service.get_iso_monday())
+
+        if not missing_squads:
+            await update.message.reply_text(format_lead_summary([]))
+            return
+
+        # 4. Send Reminders
+        success_names, failed_names = await service.send_reminders(missing_squads, user_id)
+
+        # 5. Report Summary to Lead
+        response_text = format_lead_summary(success_names, failed_names)
+        await update.message.reply_text(response_text, parse_mode="Markdown")
+
+    except Exception as e:
+        logger.exception("Error during /remind execution")
+        await update.message.reply_text("❌ An error occurred while processing reminders. Please check logs.")
+    finally:
+        db.close()

--- a/app/bot/router.py
+++ b/app/bot/router.py
@@ -1,9 +1,13 @@
 from telegram.ext import Application, CommandHandler
 
 from app.bot.handlers.status_handler import StatusHandler
+from app.bot.handlers.remind_handler import remind_command
 
 
 def setup_router(application: Application, session_factory) -> None:
     """Registers all bot command handlers with the application."""
     status_handler = StatusHandler(session_factory)
     application.add_handler(CommandHandler("status", status_handler.handle))
+
+    # Register /remind command
+    application.add_handler(CommandHandler("remind", remind_command))

--- a/app/models/squad.py
+++ b/app/models/squad.py
@@ -1,0 +1,44 @@
+"""
+SQLAlchemy models for Squads and Reminders.
+"""
+from datetime import date, datetime
+from sqlalchemy import Column, Integer, BigInteger, String, Date, TIMESTAMP, UniqueConstraint, ForeignKey
+from sqlalchemy.orm import relationship
+from app.db.base import Base
+
+class Squad(Base):
+    __tablename__ = "squads"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), unique=True, nullable=False, index=True)
+    telegram_chat_id = Column(BigInteger, nullable=True) # Nullable allows DM fallback
+    created_at = Column(TIMESTAMP, default=datetime.utcnow)
+
+    # Relationships
+    members = relationship("SquadMember", back_populates="squad", cascade="all, delete-orphan")
+    reminder_logs = relationship("ReminderLog", back_populates="squad", cascade="all, delete-orphan")
+
+class SquadMember(Base):
+    __tablename__ = "squad_members"
+    __table_args__ = (UniqueConstraint('squad_id', 'telegram_id', name='_squad_member_uc'),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    squad_id = Column(Integer, ForeignKey("squads.id"), nullable=False)
+    telegram_id = Column(BigInteger, nullable=False)
+    created_at = Column(TIMESTAMP, default=datetime.utcnow)
+
+    # Relationships
+    squad = relationship("Squad", back_populates="members")
+
+class ReminderLog(Base):
+    __tablename__ = "reminder_log"
+    __table_args__ = (UniqueConstraint('squad_id', 'week_date', name='_reminder_squad_week_uc'),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    squad_id = Column(Integer, ForeignKey("squads.id"), nullable=False)
+    week_date = Column(Date, nullable=False) # Represents the ISO Monday of the week
+    reminded_at = Column(TIMESTAMP, default=datetime.utcnow)
+    reminded_by_telegram_id = Column(BigInteger, nullable=False)
+
+    # Relationships
+    squad = relationship("Squad", back_populates="reminder_logs")

--- a/app/services/reminder_service.py
+++ b/app/services/reminder_service.py
@@ -1,0 +1,130 @@
+"""
+Core logic for the /remind command.
+Handles identifying missing squads, sending messages, and logging.
+"""
+import os
+import logging
+from datetime import date, timedelta
+from typing import List, Tuple, Optional
+from sqlalchemy.orm import Session
+from sqlalchemy import and_
+
+from app.models.squad import Squad, SquadMember, ReminderLog
+from app.models.weekly_report import WeeklyReport
+
+# Assuming a bot client interface exists or is passed in.
+# We will define a protocol or interface here for the dependency injection.
+from app.bot.client import BotClient
+
+logger = logging.getLogger(__name__)
+
+class ReminderService:
+    def __init__(self, db: Session, bot: BotClient):
+        self.db = db
+        self.bot = bot
+
+    def get_iso_monday(self) -> date:
+        """Returns the ISO Monday for the current week."""
+        today = date.today()
+        # weekday() returns 0 for Monday, 6 for Sunday
+        return today - timedelta(days=today.weekday())
+
+    def get_missing_squads(self, week_date: date) -> List[Squad]:
+        """
+        Identifies squads that have not submitted a weekly update.
+        A squad is 'missing' if ANY member has no WeeklyReport for the current week.
+        Also filters out squads that have already been reminded this week.
+        """
+        # 1. Get all squads
+        all_squads = self.db.query(Squad).all()
+
+        missing_squads = []
+
+        for squad in all_squads:
+            # Check if already reminded (Idempotency check)
+            already_reminded = self.db.query(ReminderLog).filter(
+                ReminderLog.squad_id == squad.id,
+                ReminderLog.week_date == week_date
+            ).first()
+
+            if already_reminded:
+                logger.info(f"Squad {squad.name} already reminded for {week_date}. Skipping.")
+                continue
+
+            # Check submission status
+            # Get all member IDs for this squad
+            member_ids = [m.telegram_id for m in squad.members]
+
+            if not member_ids:
+                logger.warning(f"Squad {squad.name} has no members. Skipping.")
+                continue
+
+            # Check if every member has a report for this week
+            # Logic: Squad is missing if ANY member has no report
+            reports = self.db.query(WeeklyReport.telegram_id).filter(
+                WeeklyReport.telegram_id.in_(member_ids),
+                WeeklyReport.report_date == week_date
+            ).all()
+
+            submitted_ids = {r[0] for r in reports}
+            missing_member_ids = [mid for mid in member_ids if mid not in submitted_ids]
+
+            if missing_member_ids:
+                missing_squads.append(squad)
+                logger.info(f"Squad {squad.name} is missing updates. Missing members: {missing_member_ids}")
+
+        return missing_squads
+
+    async def send_reminders(self, squads: List[Squad], actor_telegram_id: int) -> Tuple[List[str], List[str]]:
+        """
+        Sends reminders to the list of squads.
+        Returns a tuple of (successful_squad_names, failed_squad_names).
+        """
+        week_date = self.get_iso_monday()
+        success_names = []
+        failed_names = []
+
+        for squad in squads:
+            try:
+                # Determine destination: Chat ID or DM individual members
+                # Fallback: If telegram_chat_id is NULL, DM members
+                targets = []
+
+                if squad.telegram_chat_id:
+                    targets.append(squad.telegram_chat_id)
+                else:
+                    # Fallback to DMs
+                    targets = [m.telegram_id for m in squad.members]
+
+                message_text = f"👋 *Weekly Update Reminder*\n\n" \
+                               f"Hi team {squad.name}! It looks like your weekly standup update is missing or incomplete.\n\n" \
+                               f"Please take a moment to submit your update now.\n" \
+                               f"Use the /submit command to report."
+
+                sent_count = 0
+                for target_id in targets:
+                    try:
+                        await self.bot.send_message(chat_id=target_id, text=message_text, parse_mode="Markdown")
+                        sent_count += 1
+                    except Exception as e:
+                        logger.error(f"Failed to send reminder to {target_id} for squad {squad.name}: {e}")
+
+                if sent_count > 0:
+                    # Log successful reminder (Idempotency Gate)
+                    log_entry = ReminderLog(
+                        squad_id=squad.id,
+                        week_date=week_date,
+                        reminded_by_telegram_id=actor_telegram_id
+                    )
+                    self.db.add(log_entry)
+                    self.db.commit()
+                    success_names.append(squad.name)
+                else:
+                    failed_names.append(squad.name)
+
+            except Exception as e:
+                logger.error(f"Critical error processing reminder for squad {squad.name}: {e}")
+                self.db.rollback()
+                failed_names.append(squad.name)
+
+        return success_names, failed_names

--- a/db/migrations/0003_add_squads_reminder.sql
+++ b/db/migrations/0003_add_squads_reminder.sql
@@ -1,0 +1,39 @@
+-- Migration: Add Squads and Reminder System
+-- Created: Backend Agent
+-- Description: Adds tables to support squads, membership, and reminder idempotency.
+
+BEGIN;
+
+-- Create squads table
+CREATE TABLE IF NOT EXISTS squads (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    telegram_chat_id BIGINT, -- Nullable to support squads without a shared channel
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create squad_members table
+CREATE TABLE IF NOT EXISTS squad_members (
+    id SERIAL PRIMARY KEY,
+    squad_id INTEGER NOT NULL REFERENCES squads(id) ON DELETE CASCADE,
+    telegram_id BIGINT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(squad_id, telegram_id) -- A user can only belong to a squad once
+);
+
+-- Create reminder_log table
+CREATE TABLE IF NOT EXISTS reminder_log (
+    id SERIAL PRIMARY KEY,
+    squad_id INTEGER NOT NULL REFERENCES squads(id) ON DELETE CASCADE,
+    week_date DATE NOT NULL, -- ISO Monday of the week
+    reminded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    reminded_by_telegram_id BIGINT NOT NULL, -- Who triggered the reminder
+    UNIQUE(squad_id, week_date) -- Idempotency: one reminder per squad per week
+);
+
+-- Indexes for performance
+CREATE INDEX idx_squad_members_squad_id ON squad_members(squad_id);
+CREATE INDEX idx_squad_members_telegram_id ON squad_members(telegram_id);
+CREATE INDEX idx_reminder_log_week ON reminder_log(week_date);
+
+COMMIT;

--- a/tests/handlers/test_remind_handler.py
+++ b/tests/handlers/test_remind_handler.py
@@ -1,0 +1,64 @@
+import os
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from telegram import Update, User, Message, Chat
+from telegram.ext import ContextTypes
+
+from app.bot.handlers.remind_handler import remind_command
+
+@pytest.fixture
+def update():
+    u = Update(1)
+    u.effective_user = MagicMock(id=12345, first_name="Test")
+    u.message = MagicMock()
+    u.message.reply_text = AsyncMock()
+    return u
+
+@pytest.fixture
+def context():
+    c = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
+    c.bot = MagicMock()
+    c.bot.send_message = AsyncMock()
+    return c
+
+@pytest.mark.asyncio
+async def test_unauthorized_user(update, context):
+    """Test that non-QA Leads are rejected."""
+    # Set env var to NOT include user ID 12345
+    with patch.dict(os.environ, {"QA_LEAD_IDS": "99999"}):
+        await remind_command(update, context)
+
+    update.message.reply_text.assert_called_once()
+    args = update.message.reply_text.call_args[0][0]
+    assert "permission" in args.lower()
+
+@pytest.mark.asyncio
+@patch("app.bot.handlers.remind_handler.get_db")
+@patch("app.bot.handlers.remind_handler.ReminderService")
+async def test_authorized_user_success(mock_service_class, mock_get_db, update, context):
+    """Test successful execution by QA Lead."""
+    # Mock Env
+    with patch.dict(os.environ, {"QA_LEAD_IDS": "12345"}):
+        # Mock DB Session
+        mock_db = MagicMock()
+        mock_get_db.return_value = iter([mock_db]) # generator behavior
+
+        # Mock Service behavior
+        mock_instance = MagicMock()
+        mock_instance.get_iso_monday.return_value = "2023-01-01"
+        mock_instance.get_missing_squads.return_value = [] # All submitted
+        mock_service_class.return_value = mock_instance
+
+        await remind_command(update, context)
+
+        # Verify service was initialized with DB and Bot
+        mock_service_class.assert_called_once_with(mock_db, context.bot)
+
+        # Verify logic path
+        mock_instance.get_missing_squads.assert_called_once()
+
+        # Verify response
+        update.message.reply_text.assert_called_once()
+        response = update.message.reply_text.call_args[0][0]
+        assert "No reminders needed" in response or "All squads" in response

--- a/tests/services/test_reminder_service.py
+++ b/tests/services/test_reminder_service.py
@@ -1,0 +1,173 @@
+import pytest
+from datetime import date, timedelta
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.db.base import Base
+from app.models.squad import Squad, SquadMember, ReminderLog
+from app.models.weekly_report import WeeklyReport
+from app.services.reminder_service import ReminderService
+
+# Setup in-memory DB
+ENGINE = create_engine("sqlite:///:memory:")
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=ENGINE)
+
+@pytest.fixture
+def db():
+    Base.metadata.create_all(bind=ENGINE)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=ENGINE)
+
+@pytest.fixture
+def mock_bot():
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+    return bot
+
+def test_get_iso_monday():
+    service = ReminderService(None, None) # DB not needed for this specific method
+    today = date.today()
+    expected_monday = today - timedelta(days=today.weekday())
+    assert service.get_iso_monday() == expected_monday
+
+def test_get_missing_squads_all_submitted(db, mock_bot):
+    """
+    Scenario: 2 Squads. All members submitted.
+    Expected: Empty list.
+    """
+    # Setup Data
+    week_date = date(2023, 10, 23) # Monday
+
+    squad1 = Squad(name="Alpha", telegram_chat_id=100)
+    squad2 = Squad(name="Beta", telegram_chat_id=200)
+    db.add_all([squad1, squad2])
+    db.commit()
+
+    member1 = SquadMember(squad_id=squad1.id, telegram_id=1001)
+    member2 = SquadMember(squad_id=squad2.id, telegram_id=2001)
+    db.add_all([member1, member2])
+    db.commit()
+
+    # Add reports
+    report1 = WeeklyReport(telegram_id=1001, report_date=week_date, content="Done")
+    report2 = WeeklyReport(telegram_id=2001, report_date=week_date, content="Done")
+    db.add_all([report1, report2])
+    db.commit()
+
+    service = ReminderService(db, mock_bot)
+    missing = service.get_missing_squads(week_date)
+
+    assert len(missing) == 0
+
+def test_get_missing_squads_partial_submission(db, mock_bot):
+    """
+    Scenario: Squad has 2 members, 1 submitted.
+    Expected: Squad is in missing list (as per tech spec: ANY member missing).
+    """
+    week_date = date(2023, 10, 23)
+
+    squad = Squad(name="Gamma", telegram_chat_id=300)
+    db.add(squad)
+    db.commit()
+
+    mem1 = SquadMember(squad_id=squad.id, telegram_id=3001)
+    mem2 = SquadMember(squad_id=squad.id, telegram_id=3002)
+    db.add_all([mem1, mem2])
+    db.commit()
+
+    # Only mem1 submitted
+    report = WeeklyReport(telegram_id=3001, report_date=week_date, content="Done")
+    db.add(report)
+    db.commit()
+
+    service = ReminderService(db, mock_bot)
+    missing = service.get_missing_squads(week_date)
+
+    assert len(missing) == 1
+    assert missing[0].name == "Gamma"
+
+def test_idempotency(db, mock_bot):
+    """
+    Scenario: Squad missing, but already in ReminderLog for this week.
+    Expected: Squad not returned in missing list.
+    """
+    week_date = date(2023, 10, 23)
+
+    squad = Squad(name="Delta", telegram_chat_id=400)
+    db.add(squad)
+    db.commit()
+
+    mem = SquadMember(squad_id=squad.id, telegram_id=4001)
+    db.add(mem)
+    db.commit()
+
+    # Add reminder log (simulating previous run)
+    log = ReminderLog(squad_id=squad.id, week_date=week_date, reminded_by_telegram_id=999)
+    db.add(log)
+    db.commit()
+
+    service = ReminderService(db, mock_bot)
+    missing = service.get_missing_squads(week_date)
+
+    assert len(missing) == 0
+
+@pytest.mark.asyncio
+async def test_send_reminders_success(db, mock_bot):
+    """
+    Scenario: Send reminder to a squad with a chat ID.
+    Expected: Message sent to chat, ReminderLog created.
+    """
+    week_date = date(2023, 10, 23)
+    squad = Squad(name="Epsilon", telegram_chat_id=500)
+    db.add(squad)
+    db.commit()
+
+    service = ReminderService(db, mock_bot)
+    success, failed = await service.send_reminders([squad], actor_telegram_id=999)
+
+    assert len(success) == 1
+    assert "Epsilon" in success
+    assert len(failed) == 0
+
+    # Verify bot called
+    mock_bot.send_message.assert_called_once()
+    call_args = mock_bot.send_message.call_args
+    assert call_args[1]['chat_id'] == 500
+    assert "Epsilon" in call_args[1]['text']
+
+    # Verify Log
+    log = db.query(ReminderLog).filter(ReminderLog.squad_id == squad.id).first()
+    assert log is not None
+    assert log.week_date == week_date
+
+@pytest.mark.asyncio
+async def test_send_reminders_fallback_dm(db, mock_bot):
+    """
+    Scenario: Squad has NO chat ID.
+    Expected: Message sent to individual members.
+    """
+    week_date = date(2023, 10, 23)
+    squad = Squad(name="Zeta", telegram_chat_id=None) # No group chat
+    db.add(squad)
+    db.commit()
+
+    mem1 = SquadMember(squad_id=squad.id, telegram_id=6001)
+    mem2 = SquadMember(squad_id=squad.id, telegram_id=6002)
+    db.add_all([mem1, mem2])
+    db.commit()
+
+    service = ReminderService(db, mock_bot)
+    success, failed = await service.send_reminders([squad], actor_telegram_id=999)
+
+    assert len(success) == 1
+    assert mock_bot.send_message.call_count == 2 # Called for each member
+
+    # Verify chat IDs used were the member IDs
+    ids_called = [call[1]['chat_id'] for call in mock_bot.send_message.call_args_list]
+    assert 6001 in ids_called
+    assert 6002 in ids_called


### PR DESCRIPTION
## Summary
- Add DB migration for squads, squad_members, and reminder_log tables
- Add SQLAlchemy models (Squad, SquadMember, ReminderLog)
- Add ReminderService with idempotent missing-squad detection and reminder dispatch
- Add /remind command handler restricted to QA_LEAD_IDS
- Register handler in router; add unit tests for service and handler layers

## Test plan
- [ ] Run migration: `psql < db/migrations/0003_add_squads_reminder.sql`
- [ ] Set `QA_LEAD_IDS` env var to your Telegram user ID
- [ ] Send `/remind` as QA Lead — verify squads missing reports receive a message
- [ ] Send `/remind` again immediately — verify no duplicate messages (idempotency)
- [ ] Send `/remind` as non-lead — verify permission denial
- [ ] Run `pytest tests/services/test_reminder_service.py tests/handlers/test_remind_handler.py`

Closes #16